### PR TITLE
Added createMobBucketItem method

### DIFF
--- a/src/main/java/com/teamabnormals/blueprint/core/util/registry/ItemSubRegistryHelper.java
+++ b/src/main/java/com/teamabnormals/blueprint/core/util/registry/ItemSubRegistryHelper.java
@@ -1,16 +1,20 @@
 package com.teamabnormals.blueprint.core.util.registry;
 
 import com.teamabnormals.blueprint.common.item.BlueprintBoatItem;
+import com.teamabnormals.blueprint.common.item.BlueprintMobBucketItem;
 import com.teamabnormals.blueprint.common.item.FuelItem;
 import com.teamabnormals.blueprint.core.registry.BoatRegistry;
+import net.minecraft.sounds.SoundEvents;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.Mob;
+import net.minecraft.world.entity.animal.WaterAnimal;
 import net.minecraft.world.item.BlockItem;
 import net.minecraft.world.item.CreativeModeTab;
 import net.minecraft.world.item.DoubleHighBlockItem;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.StandingAndWallBlockItem;
 import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.material.Fluids;
 import net.minecraftforge.common.ForgeSpawnEggItem;
 import net.minecraftforge.fml.ModList;
 import net.minecraftforge.registries.DeferredRegister;
@@ -144,6 +148,18 @@ public class ItemSubRegistryHelper extends AbstractSubRegistryHelper<Item> {
 	 */
 	public RegistryObject<ForgeSpawnEggItem> createSpawnEggItem(String entityName, Supplier<EntityType<? extends Mob>> supplier, int primaryColor, int secondaryColor) {
 		return this.deferredRegister.register(entityName + "_spawn_egg", () -> new ForgeSpawnEggItem(supplier, primaryColor, secondaryColor, new Item.Properties().tab(CreativeModeTab.TAB_MISC)));
+	}
+
+	/**
+	 * Creates and registers a {@link BlueprintMobBucketItem}.
+	 *
+	 * @param entityName	The name of the entity in this bucket.
+	 * @param supplier		The supplied {@link EntityType}.
+	 * @return A {@link RegistryObject} containing the {@link BlueprintMobBucketItem}.
+	 * @see BlueprintMobBucketItem
+	 */
+	public RegistryObject<Item> createMobBucketItem(String entityName, Supplier<EntityType<? extends WaterAnimal>> supplier) {
+		return this.deferredRegister.register(entityName + "_bucket", () -> new BlueprintMobBucketItem(supplier, () -> Fluids.WATER, () -> SoundEvents.BUCKET_EMPTY_FISH, new Item.Properties().stacksTo(1).tab(CreativeModeTab.TAB_MISC)));
 	}
 
 	/**

--- a/src/test/java/core/BlueprintTest.java
+++ b/src/test/java/core/BlueprintTest.java
@@ -14,6 +14,7 @@ import com.teamabnormals.blueprint.core.util.DataUtil;
 import com.teamabnormals.blueprint.core.util.registry.RegistryHelper;
 import common.world.TestGlobalStorage;
 import core.registry.*;
+import net.minecraft.client.renderer.entity.CodRenderer;
 import net.minecraft.client.renderer.entity.CowRenderer;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.sounds.SoundEvents;
@@ -80,6 +81,7 @@ public final class BlueprintTest {
 	@OnlyIn(Dist.CLIENT)
 	private void rendererSetup(EntityRenderersEvent.RegisterRenderers event) {
 		event.registerEntityRenderer(TestEntities.COW.get(), CowRenderer::new);
+		event.registerEntityRenderer(TestEntities.COD.get(), CodRenderer::new);
 		event.registerEntityRenderer(TestEntities.ENDIMATED_TEST.get(), TestEndimatedEntityRenderer::new);
 		event.registerEntityRenderer(TestEntities.ENDIMATED_WALKING.get(), EndimatedWalkingEntityRenderer::new);
 		event.registerBlockEntityRenderer(TestBlockEntities.TEST_ENDIMATED.get(), TestEndimatedBlockEntityRenderer::new);

--- a/src/test/java/core/registry/TestEntities.java
+++ b/src/test/java/core/registry/TestEntities.java
@@ -7,6 +7,7 @@ import core.BlueprintTest;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.MobCategory;
 import net.minecraft.world.entity.PathfinderMob;
+import net.minecraft.world.entity.animal.Cod;
 import net.minecraft.world.entity.animal.Cow;
 import net.minecraftforge.event.entity.EntityAttributeCreationEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
@@ -18,12 +19,14 @@ public final class TestEntities {
 	private static final EntitySubRegistryHelper HELPER = BlueprintTest.REGISTRY_HELPER.getEntitySubHelper();
 
 	public static final RegistryObject<EntityType<Cow>> COW = HELPER.createLivingEntity("example", Cow::new, MobCategory.CREATURE, 1.0F, 1.0F);
+	public static final RegistryObject<EntityType<Cod>> COD = HELPER.createLivingEntity("fish_example", Cod::new, MobCategory.WATER_AMBIENT, 1.0F, 1.0F);
 	public static final RegistryObject<EntityType<TestEndimatedEntity>> ENDIMATED_TEST = HELPER.createLivingEntity("endimated_test", TestEndimatedEntity::new, MobCategory.CREATURE, 1.0F, 1.0F);
 	public static final RegistryObject<EntityType<EndimatedWalkingEntity>> ENDIMATED_WALKING = HELPER.createLivingEntity("endimated_walking", EndimatedWalkingEntity::new, MobCategory.CREATURE, 1.0F, 1.0F);
 
 	@SubscribeEvent
 	public static void registerAttributes(EntityAttributeCreationEvent event) {
 		event.put(TestEntities.COW.get(), Cow.createAttributes().build());
+		event.put(TestEntities.COD.get(), Cod.createAttributes().build());
 		event.put(TestEntities.ENDIMATED_TEST.get(), PathfinderMob.createMobAttributes().build());
 		event.put(TestEntities.ENDIMATED_WALKING.get(), PathfinderMob.createMobAttributes().build());
 	}

--- a/src/test/java/core/registry/TestItems.java
+++ b/src/test/java/core/registry/TestItems.java
@@ -16,6 +16,7 @@ public final class TestItems {
 	public static final RegistryObject<Item> ITEM = HELPER.createTest();
 	public static final RegistryObject<ForgeSpawnEggItem> COW_SPAWN_EGG = HELPER.createItem("test_spawn_egg", () -> new ForgeSpawnEggItem(TestEntities.COW, 100, 200, new Item.Properties().tab(CreativeModeTab.TAB_MISC)));
 	public static final RegistryObject<Item> BOAT = HELPER.createBoatItem("test", TestBlocks.BLOCK);
+	public static final RegistryObject<Item> MOB_BUCKET = HELPER.createMobBucketItem("test", TestEntities.COD::get);
 
 	public static class Helper extends ItemSubRegistryHelper {
 

--- a/src/test/resources/assets/blueprint_test/models/item/test_bucket.json
+++ b/src/test/resources/assets/blueprint_test/models/item/test_bucket.json
@@ -1,0 +1,6 @@
+{
+  "parent": "minecraft:item/generated",
+  "textures": {
+    "layer0": "minecraft:item/cod_bucket"
+  }
+}


### PR DESCRIPTION
This PR adds a `createMobBucketItem` method to the `ItemSubRegistryHelper`
The method creates and registers a `BlueprintMobBucketItem` with an `EntityType` Supplier that extends `WaterAnimal`.

This PR also adds a Test for this method even though I wasn't sure if that's necessary.

I originally had this method separately in my mod, but since I'm using Blueprint anyways I thought I could create this PR, so others can use it too! 