### PR TITLE
Clear SelectionSpace reference from ObjectModificationManager after reload

### DIFF
--- a/src/main/java/com/teamabnormals/blueprint/core/util/modification/ObjectModificationManager.java
+++ b/src/main/java/com/teamabnormals/blueprint/core/util/modification/ObjectModificationManager.java
@@ -142,7 +142,7 @@ public class ObjectModificationManager<T, S, D> extends SimpleJsonResourceReload
 			}
 		}
 		Blueprint.LOGGER.info(type + " Modification Manager has loaded {} modifier groups", groupsLoaded);
-		// if this is not cleared, all JSON objects are kept in memory forever
+		// Empty Selection Space to prevent memory from lying around until the next reload
 		this.selectionSpace = consumer -> {};
 	}
 

--- a/src/main/java/com/teamabnormals/blueprint/core/util/modification/ObjectModificationManager.java
+++ b/src/main/java/com/teamabnormals/blueprint/core/util/modification/ObjectModificationManager.java
@@ -142,6 +142,8 @@ public class ObjectModificationManager<T, S, D> extends SimpleJsonResourceReload
 			}
 		}
 		Blueprint.LOGGER.info(type + " Modification Manager has loaded {} modifier groups", groupsLoaded);
+		// if this is not cleared, all JSON objects are kept in memory forever
+		this.selectionSpace = consumer -> {};
 	}
 
 	/**


### PR DESCRIPTION
I discovered this memory leak by profiling FTB Skies. From what I can tell the `selectionSpace` object is not needed after `apply` finishes, so it can be simply be reset to the default empty function. Doing this can save at least 60MB in larger modpacks, as this object ends up retaining JSON objects that the game would otherwise have freed. 
