### PR TITLE
add more functionality to BasicRegistry

### DIFF
--- a/src/main/java/com/teamabnormals/blueprint/core/util/registry/BasicRegistry.java
+++ b/src/main/java/com/teamabnormals/blueprint/core/util/registry/BasicRegistry.java
@@ -7,23 +7,31 @@ import com.mojang.serialization.Codec;
 import com.mojang.serialization.DataResult;
 import com.mojang.serialization.DynamicOps;
 import com.mojang.serialization.Lifecycle;
+import net.minecraft.core.IdMap;
 import net.minecraft.resources.ResourceLocation;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import java.util.Iterator;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
+import java.util.stream.Stream;
 
 /**
  * A simplified version of the {@link net.minecraft.core.Registry} class.
  * <p>This class is not an instance of {@link net.minecraft.core.Registry}</p>
+ * <p>Values can be added at any time, independent of {@link net.minecraftforge.registries.RegisterEvent}.</p>
  *
  * @param <T> The type of object for the registry.
  * @author SmellyModder (Luke Tonon)
+ * @author ebo2022
  */
-public final class BasicRegistry<T> implements Codec<T> {
+public final class BasicRegistry<T> implements Codec<T>, IdMap<T> {
 	private final Lifecycle lifecycle;
 	private final BiMap<String, T> map = HashBiMap.create();
+	private final BiMap<T, Integer> idMap = HashBiMap.create();
+	private int nextId;
 
 	public BasicRegistry(Lifecycle lifecycle) {
 		this.lifecycle = lifecycle;
@@ -41,6 +49,8 @@ public final class BasicRegistry<T> implements Codec<T> {
 	 */
 	public void register(String name, T value) {
 		this.map.put(name, value);
+		this.idMap.put(value, this.nextId);
+		this.nextId++;
 	}
 
 	/**
@@ -59,7 +69,7 @@ public final class BasicRegistry<T> implements Codec<T> {
 	 * @return This registry's {@link #lifecycle}.
 	 */
 	@Nonnull
-	public Lifecycle getLifecycle() {
+	public Lifecycle registryLifecycle() {
 		return this.lifecycle;
 	}
 
@@ -70,7 +80,7 @@ public final class BasicRegistry<T> implements Codec<T> {
 	 * @return A value for a given {@link String} name, or null if there's no value for the given {@link String}.
 	 */
 	@Nullable
-	public T getValue(String name) {
+	public T get(String name) {
 		return this.map.get(name);
 	}
 
@@ -101,7 +111,7 @@ public final class BasicRegistry<T> implements Codec<T> {
 	 * @return A set of all the registered values in this registry.
 	 */
 	@Nonnull
-	public Set<T> getValues() {
+	public Set<T> values() {
 		return this.map.values();
 	}
 
@@ -111,7 +121,7 @@ public final class BasicRegistry<T> implements Codec<T> {
 	 * @return A set of all the entries in this registry.
 	 */
 	@Nonnull
-	public Set<Map.Entry<String, T>> getEntries() {
+	public Set<Map.Entry<String, T>> entrySet() {
 		return this.map.entrySet();
 	}
 
@@ -125,11 +135,51 @@ public final class BasicRegistry<T> implements Codec<T> {
 		return this.map.containsKey(name);
 	}
 
+	/**
+	 * Gets the id for a given value.
+	 *
+	 * @return The id for a given value, or null if the value isn't registered.
+	 */
+	@Override
+	public int getId(T value) {
+		return Objects.requireNonNullElse(this.idMap.get(value), DEFAULT);
+	}
+
+	/**
+	 * Gets a registry value with the given id.
+	 *
+	 * @param id An id to check for a registry value with.
+	 * @return A registry value with the given id, or null if the id is out of range or no value is registered under the id.
+	 */
+	@Override
+	public T byId(int id) {
+		return id >= 0 && id < this.idMap.size() ? this.idMap.inverse().get(id) : null;
+	}
+
+	/**
+	 * Gets the number of values added to this registry.
+	 *
+	 * @return The number of values added to this registry.
+	 */
+	@Override
+	public int size() {
+		return this.map.size();
+	}
+
+	/**
+	 * Gets a {@link Stream} of all values added to this registry.
+	 *
+	 * @return A {@link Stream} of all values added to this registry.
+	 */
+	public Stream<T> stream() {
+		return this.map.values().stream();
+	}
+
 	@Override
 	public <U> DataResult<Pair<T, U>> decode(DynamicOps<U> ops, U input) {
 		return Codec.STRING.decode(ops, input).flatMap((encodedRegistryPair) -> {
 			String name = encodedRegistryPair.getFirst();
-			T value = this.getValue(name);
+			T value = this.get(name);
 			return value == null ? DataResult.error(() -> "Unknown registry key: " + name) : DataResult.success(Pair.of(value, encodedRegistryPair.getSecond()), this.lifecycle);
 		});
 	}
@@ -141,5 +191,10 @@ public final class BasicRegistry<T> implements Codec<T> {
 			return DataResult.error(() -> "Unknown registry element: " + prefix);
 		}
 		return ops.mergeToPrimitive(prefix, ops.createString(name)).setLifecycle(this.lifecycle);
+	}
+
+	@Override
+	public Iterator<T> iterator() {
+		return this.map.values().iterator();
 	}
 }

--- a/src/main/java/com/teamabnormals/blueprint/core/util/registry/BasicRegistry.java
+++ b/src/main/java/com/teamabnormals/blueprint/core/util/registry/BasicRegistry.java
@@ -34,12 +34,11 @@ public final class BasicRegistry<T> implements Codec<T>, IdMap<T> {
 	private final Lifecycle lifecycle;
 	private final BiMap<String, T> map = HashBiMap.create();
 	private final ObjectList<T> byId = new ObjectArrayList<>();
-	private final Object2IntMap<T> toId;
+	private final Object2IntMap<T> toId = new Object2IntOpenCustomHashMap<>(Util.identityStrategy());
 	private int nextId;
 
 	public BasicRegistry(Lifecycle lifecycle) {
 		this.lifecycle = lifecycle;
-		this.toId = new Object2IntOpenCustomHashMap<>(Util.identityStrategy());
 		this.toId.defaultReturnValue(IdMap.DEFAULT);
 	}
 
@@ -54,12 +53,11 @@ public final class BasicRegistry<T> implements Codec<T>, IdMap<T> {
 	 * @param value A value to register.
 	 */
 	public void register(String name, T value) {
-		int id = this.nextId;
+		int id = this.nextId++;
 		this.map.put(name, value);
 		this.byId.size(id + 1);
 		this.byId.set(id, value);
 		this.toId.put(value, id);
-		this.nextId++;
 	}
 
 	/**
@@ -161,6 +159,7 @@ public final class BasicRegistry<T> implements Codec<T>, IdMap<T> {
 	 * @return A registry value with the given id, or null if the id is out of range or no value is registered under the id.
 	 */
 	@Override
+	@Nullable
 	public T byId(int id) {
 		return id >= 0 && id < this.byId.size() ? this.byId.get(id) : null;
 	}

--- a/src/main/java/com/teamabnormals/blueprint/core/util/registry/BasicRegistry.java
+++ b/src/main/java/com/teamabnormals/blueprint/core/util/registry/BasicRegistry.java
@@ -21,7 +21,7 @@ import java.util.stream.Stream;
 /**
  * A simplified version of the {@link net.minecraft.core.Registry} class.
  * <p>This class is not an instance of {@link net.minecraft.core.Registry}</p>
- * <p>Values can be added at any time, independent of {@link net.minecraftforge.registries.RegisterEvent}.</p>
+ * <p>Values can be added at any time, independent of {@link net.minecraftforge.registries.RegisterEvent}</p>
  *
  * @param <T> The type of object for the registry.
  * @author SmellyModder (Luke Tonon)
@@ -138,7 +138,7 @@ public final class BasicRegistry<T> implements Codec<T>, IdMap<T> {
 	/**
 	 * Gets the id for a given value.
 	 *
-	 * @return The id for a given value, or null if the value isn't registered.
+	 * @return The id for a given value, or -1 if the value isn't registered.
 	 */
 	@Override
 	public int getId(T value) {


### PR DESCRIPTION
Adds `IdMap` and `Iterable`-related methods to the class. Also changes some method names to be inline with their corresponding vanilla counterparts.